### PR TITLE
Move nose to extras requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ def install_requires():
             req.append('mapnik2')
     return req
 
+develop_requirements = install_requires() + ['nose>=1.0']
+
 setup(
     name='pycnik',
     version=__import__('pycnik').__version__,
@@ -64,7 +66,9 @@ setup(
         ],
     packages=['pycnik'],
     install_requires=install_requires(),
+    extras_require={
+        'develop': develop_requirements,
+    },
     entry_points=dict(console_scripts=['pycnik=pycnik:main', ]),
-    setup_requires=['nose>=1.0'],
     test_suite='nose.collector'
 )


### PR DESCRIPTION
Pycnik requires that the package "nose" is already installed for his installation

```
You are using pip version 6.0.6, however version 7.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Collecting pycnik
  Using cached pycnik-1.4.tar.gz
    Couldn't find index page for 'nose' (maybe misspelled?)
    No local packages or download links found for nose>=1.0
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-7dYtdn/pycnik/setup.py", line 69, in <module>
        test_suite='nose.collector'
      File "/usr/lib64/python2.7/distutils/core.py", line 111, in setup
        _setup_distribution = dist = klass(attrs)
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/setuptools/dist.py", line 266, in __init__
        self.fetch_build_eggs(attrs['setup_requires'])
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/setuptools/dist.py", line 312, in fetch_build_eggs
        replace_conflicting=True,
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/pkg_resources/__init__.py", line 753, in resolve
        dist = best[req.key] = env.best_match(req, ws, installer)
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1005, in best_match
        return self.obtain(req, installer)
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1017, in obtain
        return installer(requirement)
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/setuptools/dist.py", line 379, in fetch_build_egg
        return cmd.easy_install(req)
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 613, in easy_install
        raise DistutilsError(msg)
    distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('nose>=1.0')
    Complete output from command python setup.py egg_info:
    Couldn't find index page for 'nose' (maybe misspelled?)
    
    No local packages or download links found for nose>=1.0
    
    Traceback (most recent call last):
    
      File "<string>", line 20, in <module>
    
      File "/tmp/pip-build-7dYtdn/pycnik/setup.py", line 69, in <module>
    
        test_suite='nose.collector'
    
      File "/usr/lib64/python2.7/distutils/core.py", line 111, in setup
    
        _setup_distribution = dist = klass(attrs)
    
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/setuptools/dist.py", line 266, in __init__
    
        self.fetch_build_eggs(attrs['setup_requires'])
    
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/setuptools/dist.py", line 312, in fetch_build_eggs
    
        replace_conflicting=True,
    
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/pkg_resources/__init__.py", line 753, in resolve
    
        dist = best[req.key] = env.best_match(req, ws, installer)
    
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1005, in best_match
    
        return self.obtain(req, installer)
    
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1017, in obtain
    
        return installer(requirement)
    
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/setuptools/dist.py", line 379, in fetch_build_egg
    
        return cmd.easy_install(req)
    
      File "/home/rcommande/.local/share/virtualenvs/3f3fb257d65a846/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 613, in easy_install
    
        raise DistutilsError(msg)
    
    distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('nose>=1.0')
    
    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-7dYtdn/pycnik
```
I moved "nose" to the extra requirements named  "develop" (install with `pip install pycnik[develop]`).